### PR TITLE
Support for additional scale and fixes according to the docs.

### DIFF
--- a/scales.h
+++ b/scales.h
@@ -12,7 +12,7 @@
 //
 // **NSCALES** should be kept updated with the length of the list.
 //
-#define NSCALES 6
+#define NSCALES 7
 
 //
 // What is the number of the weighing result to show, as the first result may be incorrect (from the previous weighing)

--- a/scales.h
+++ b/scales.h
@@ -12,7 +12,7 @@
 //
 // **NSCALES** should be kept updated with the length of the list.
 //
-#define NSCALES 7
+#define NSCALES 8
 
 //
 // What is the number of the weighing result to show, as the first result may be incorrect (from the previous weighing)
@@ -37,5 +37,7 @@ uint16_t scales[NSCALES][2] = {\
     // SANFORD Dymo 10 lb USB Postal Scale
     {0x6096, 0x0158},
     // Fairbanks Scales SCB-R9000
-    {0x0b67, 0x555e}
+    {0x0b67, 0x555e},
+    // Dymo-CoStar Corp. M25 Digital Postal Scale
+    {0x0922, 0x8004}
 };

--- a/usbscale.c
+++ b/usbscale.c
@@ -276,16 +276,12 @@ static int print_scale_data(unsigned char* dat) {
     uint8_t report = dat[0];
     uint8_t status = dat[1];
     uint8_t unit   = dat[2];
-    uint8_t expt   = dat[3];
-    double weight = (double)(dat[4] + (dat[5] << 8)) / 10;
-
-    if(expt != 255 && expt != 0) {
-	if (expt > 127) {
-	    weight = weight * pow(10, expt-255);
-	} else {
-	    weight = pow(weight, expt);
-	}
-    }
+    // Accoring to the docs, scaling applied to the data as a base ten exponent
+    int8_t  expt   = dat[3];
+    // convert to machine order at all times
+    double weight = (double) le16toh(dat[5] << 8 | dat[4]);
+    // since the expt is signed, we do not need no trickery
+    weight = weight * pow(10, expt);
 
     //
     // The scale's first byte, its "report", is always 3.


### PR DESCRIPTION
In the docs we read that [a numeric value representing the scaling applied to the data as ten exponent base](http://www.usb.org/developers/hidpage/pos1_02.pdf#page=30). In other words exponent value shall be signed. 

Dividing by 10 as it was on line 280 would only work for ounces. For example, DYMO M25 when set to work in grams would return them as they are, and dividing by ten would give us invalid value.

I believe this should bring #8 to closing.

