### PR TITLE
Add human-readable ounce display

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ error messages will be sent to `stderr`. An exit code of 0 means that a scale
 was found and a weight was successfully read. Any other error code indicates
 that a weight reading was unavailable.
 
+Use the `-h`/`--human` flag to format ounce measurements as pounds and
+ounces, e.g. `1 lbs 4 oz` instead of `20 oz`.
+
 ## Zeroing the scale
 
 There is somewhat-experimental support for sending a tare command to the scale.


### PR DESCRIPTION
## Summary
- allow `-h`/`--human` flag so ounce output is shown as pounds and ounces
- document the new flag in the README

## Testing
- `make`
- `./usbscale --help`
- `./usbscale -h` *(fails: No USB scale found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9d8cde148323a02f7c6cbd2b5bb4